### PR TITLE
Added functionality to scan a list of given assemblies for type params.

### DIFF
--- a/src/TanvirArjel.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/TanvirArjel.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="ServiceCollectionExtensions.cs" company="TanvirArjel">
-// Copyright (c) TanvirArjel. All rights reserved.
+// Copyright (c) TanvirArjel and Thomas Guenther. All rights reserved.
 // </copyright>
 
 using System;
@@ -17,6 +17,44 @@ namespace TanvirArjel.Extensions.Microsoft.DependencyInjection
     public static class ServiceCollectionExtensions
     {
         private static List<Assembly> _loadedAssemblies = new List<Assembly>();
+
+        /// <summary>
+        /// This will add all the types containing any of the <see cref="ScopedServiceAttribute"/>, <see cref="TransientServiceAttribute"/> and <see cref="SingletonServiceAttribute"/> attributes
+        /// to the dependency injection container.
+        /// Therefor only the list with given assemblies will be used: no directory scanning in this case.
+        /// </summary>
+        /// <typeparam name="T">Any of the <see cref="ScopedServiceAttribute"/>, <see cref="TransientServiceAttribute"/> and <see cref="SingletonServiceAttribute"/> attributes.</typeparam>
+        /// <param name="serviceCollection">Type to be extended.</param>
+        /// <param name="loadedAssemblies">A list of assembly to be scanned for type attributes.</param>
+        public static void AddServicesWithAttributeOfTypeForAssemblies<T>(this IServiceCollection serviceCollection, params Assembly[] loadedAssemblies)
+        {
+            if (serviceCollection == null)
+            {
+                throw new ArgumentNullException(nameof(serviceCollection));
+            }
+
+            _loadedAssemblies = loadedAssemblies.OfType<Assembly>().ToList();
+            AddServicesWithAttributeOfType<T>(serviceCollection);
+        }
+
+        /// <summary>
+        /// This will add all the types implementing any of the <see cref="IScopedService"/>, <see cref="ITransientService"/> and <see cref="ISingletonService"/>
+        /// interfaces to the dependency injection container.
+        /// Therefor only the list with given assemblies will be used: no directory scanning in this case.
+        /// </summary>
+        /// <typeparam name="T">Any of the <see cref="IScopedService"/>, <see cref="ITransientService"/> and <see cref="ISingletonService"/> interfaces.</typeparam>
+        /// <param name="serviceCollection">Type to be extended.</param>
+        /// <param name="loadedAssemblies">A list of assembly to be scanned for the given type param.</param>
+        public static void AddServicesOfTypeForAssemblies<T>(this IServiceCollection serviceCollection, params Assembly[] loadedAssemblies)
+        {
+            if (serviceCollection == null)
+            {
+                throw new ArgumentNullException(nameof(serviceCollection));
+            }
+
+            _loadedAssemblies = loadedAssemblies.OfType<Assembly>().ToList();
+            AddServicesOfType<T>(serviceCollection);
+        }
 
         /// <summary>
         /// This will add all the types implementing any of the <see cref="IScopedService"/>, <see cref="ITransientService"/> and <see cref="ISingletonService"/>
@@ -51,7 +89,12 @@ namespace TanvirArjel.Extensions.Microsoft.DependencyInjection
 
             if (!_loadedAssemblies.Any())
             {
+                Console.WriteLine("Scanning of assemblies necessary....");
                 LoadAssemblies(scanAssembliesStartsWith);
+            }
+            else
+            {
+                Console.WriteLine("List of assemblies already filled....");
             }
 
             List<Type> implementations = _loadedAssemblies
@@ -130,7 +173,12 @@ namespace TanvirArjel.Extensions.Microsoft.DependencyInjection
 
             if (!_loadedAssemblies.Any())
             {
+                Console.WriteLine("Scanning of assemblies necessary....");
                 LoadAssemblies(scanAssembliesStartsWith);
+            }
+            else
+            {
+                Console.WriteLine("List of assemblies already filled....");
             }
 
             List<Type> servicesToBeRegistered = _loadedAssemblies
@@ -201,7 +249,8 @@ namespace TanvirArjel.Extensions.Microsoft.DependencyInjection
                 if (scanAssembliesStartsWith.Length == 1)
                 {
                     string searchPattern = $"{scanAssembliesStartsWith.First()}*.dll";
-                    string[] assemblyPaths = Directory.GetFiles(appDllsDirectory, searchPattern);
+                    string[] assemblyPaths = Directory.GetFiles(appDllsDirectory, searchPattern, SearchOption.AllDirectories);
+
                     assembliesToBeLoaded.AddRange(assemblyPaths);
                 }
 
@@ -210,14 +259,14 @@ namespace TanvirArjel.Extensions.Microsoft.DependencyInjection
                     foreach (string starsWith in scanAssembliesStartsWith)
                     {
                         string searchPattern = $"{starsWith}*.dll";
-                        string[] assemblyPaths = Directory.GetFiles(appDllsDirectory, searchPattern);
+                        string[] assemblyPaths = Directory.GetFiles(appDllsDirectory, searchPattern, SearchOption.AllDirectories);
                         assembliesToBeLoaded.AddRange(assemblyPaths);
                     }
                 }
             }
             else
             {
-                string[] assemblyPaths = Directory.GetFiles(appDllsDirectory, "*.dll");
+                string[] assemblyPaths = Directory.GetFiles(appDllsDirectory, "*.dll", SearchOption.AllDirectories);
                 assembliesToBeLoaded.AddRange(assemblyPaths);
             }
 

--- a/src/TanvirArjel.Extensions.Microsoft.DependencyInjection/TanvirArjel.Extensions.Microsoft.DependencyInjection.csproj
+++ b/src/TanvirArjel.Extensions.Microsoft.DependencyInjection/TanvirArjel.Extensions.Microsoft.DependencyInjection.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Authors>TanvirArjel</Authors>
-    <Company>Tanvir Ahmad Arjel</Company>
+    <Authors>TanvirArjel, ThomasGuenther</Authors>
+    <Company>Tanvir Ahmad Arjel, Thomas Guenther</Company>
     <Copyright>©2019 TanvirArjel. All rights reserved.</Copyright>
     <Title>NET 5.0 and .NET Core Dynamic Service Registration</Title>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
Thanks, for your great project. It helped us a lot in getting a plugin mechanism to work where blazor components having its own services running can be dynamically loaded in a blazor webassembly app.
Therefor we needed a mechanism to register services dynamically.
I Just made small changes to ServiceCollectionExtensions.cs where the _loadedAssemblies list is just filled with a list of given assemblies befor searching for services to register.
I also added an option to also recurse into subdirectories during assembly scanning.
I just want to contribute our changes. Feel free to integrate them into your official project and therefor made any changes you like.

Kind regards
Thomas 